### PR TITLE
Bourne-shell compatibility would be nice

### DIFF
--- a/tools/c9-setup.sh
+++ b/tools/c9-setup.sh
@@ -16,9 +16,7 @@ echo "npm install"
 npm install
 
 echo "Symlinking to the globally-installed grunt..."
-pushd node_modules/.bin
-ln -s `which grunt` .
-popd
+ln -s `which grunt` node_modules/.bin
 
 echo "Doing initial schema deployment..."
 sh tools/postgres/cleandb.sh


### PR DESCRIPTION
The tools/c9_setup.sh script was failing in Bourne …was working only in bash.  Easy to make it more compatible.
